### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -16,7 +16,7 @@ icon-path = "icon.png"
 wit-version = "1.0.0"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release && cp ./target/wasm32-wasip2/release/plausible_edgee_component.wasm plausible.wasm"
+command = "cargo build --target wasm32-wasip2 --release && rm -f plausible.wasm && cp ./target/wasm32-wasip2/release/plausible_edgee_component.wasm plausible.wasm"
 output_path = "plausible.wasm"
 
 [component.settings.domain]


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink